### PR TITLE
config: add 'postgres.psql` for detail settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,29 @@ $ grep REPLACED log | sort -n -t'(' -k 3 -r | head -3
 [05:32:47] (343/428) statistics   REPLACED 2443266 (8.98s)
 ```
 
+## PostgreSQL
+
+### psql
+
+For example, if you want to use SSL, you can specify the command directly to `psql` in config.
+Here, '%' prefixed words are replaced by those settings automatically.
+
+```toml
+[postgres]
+psql = "psql -h %host -p %port -U %user %db -w --dbname=postgres --set=sslmode=require --set=sslrootcert=./sslcert.crt"
+```
+
+### authorization
+
+Using `~/.pgpass` is a easiest way to specify a password.
+
+If it is difficult to write to HOME by cron execution, you can embed it directly into the config file using `psql` above.
+
+```toml
+[postgres]
+psql = "PGPASSWORD=foo psql -h %host -p %port -U %user %db -w"
+```
+
 ## Development
 
 * using [Crystal](http://crystal-lang.org/) on docker

--- a/src/data/chef.cr
+++ b/src/data/chef.cr
@@ -23,7 +23,7 @@ class Data::Chef
   var logger : Logger = Pretty::Logger.build_logger({"path" => "STDOUT", "name" => "(chef)"})
 
   delegate table, to: recipe
-  delegate pg_db, pg_max_record_size, pg_ttl_count, to: config
+  delegate pg_max_record_size, pg_ttl_count, to: config
   delegate psql, clickhouse_client, to: config
 
   def initialize(@recipe, @config, @label, @logger)
@@ -75,7 +75,7 @@ class Data::Chef
     Pretty::File.write(count_sql, query)
     logger.debug "  created data count #{count_sql}"
 
-    psql("-f #{count_sql} #{pg_db} > #{count_csv}.tmp")
+    psql("-f #{count_sql} > #{count_csv}.tmp")
     Pretty::File.mv("#{count_csv}.tmp", count_csv)
     logger.debug "  fetched data count #{count_csv}"
 
@@ -158,7 +158,7 @@ class Data::Chef
     logger.debug "  created #{data_sql}"
 
     # write tmp then move it to avoid file creation on error
-    psql("-f #{data_sql} #{pg_db} > #{data_csv}.tmp")
+    psql("-f #{data_sql} > #{data_csv}.tmp")
     Pretty::File.mv("#{data_csv}.tmp", data_csv)
     
     logger.debug "  fetched #{data_csv}"


### PR DESCRIPTION
This PR adds a setting that allows the user to specify psql commands at will.

For example, if you want to use SSL, you can specify the command directly to `psql` in config.
Here, '%' prefixed words are replaced by those settings automatically.

```toml
[postgres]
psql = "psql -h %host -p %port -U %user %db -w --dbname=postgres --set=sslmode=require --set=sslrootcert
=./sslcert.crt"
```

For the case when you want to put password into config.

```toml
[postgres]
psql = "PGPASSWORD=foo psql -h %host -p %port -U %user %db -w"
```